### PR TITLE
Update the flag used on index.html for Kurmanji UD treebank (kmr)

### DIFF
--- a/kmr/index.html
+++ b/kmr/index.html
@@ -76,7 +76,7 @@
                 root + 'lib/ext/jquery.address.min.js'
             );
         </script>
-        <h1 id="ud-for-kurmanji-">UD for Kurmanji <span class="flagspan"><img class="flag" src="../../flags/svg/TR.svg" /></span></h1>
+        <h1 id="ud-for-kurmanji-">UD for Kurmanji <span class="flagspan"><img class="flag" src="../../flags/svg/IQ-KRD.svg" /></span></h1>
 
 <h2 id="tokenization-and-word-segmentation">Tokenization and Word Segmentation</h2>
 


### PR DESCRIPTION
Changed the flag used for Northern Kurdish (Kurmanji) from the Turkish flag to the Kurdish flag (Ala Rengîn), which is formally used by the Kurdistan Regional Government in Iraq and it's currently used for the Central Kurdish (Sorani).  

While Kurmanji is being spoken by Kurds in Turkey, the Turkish flag doesn't represent the Kurmanji or the Kurdish people. Thus, it's better to use the Kurdish flag that is used for Sorani.  