### PR TITLE
Updating Northern Kurdish (Kurmanji) flag on the home page of Universal Dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -5558,7 +5558,7 @@ Universal Dependencies](http://universaldependencies.org/conll17/).
   </div> <!-- end of Korean accordion body -->
   <!-- Except for class="jquery-ui-subaccordion-closed", all attributes of the accordion-related div elements can be generated during initialization of the page. However, the initialization takes up to 10 seconds and we want something reasonably nice to be visible as soon as possible. -->
   <div class="ui-accordion-header ui-helper-reset ui-state-default ui-corner-all" role="tab" aria-expanded="false" aria-selected="false" tabindex="-1"> <!-- start of Kurmanji accordion row -->
-    <span class="flagspan"><img class="flag" src="flags/svg/TR.svg" /></span>
+    <span class="flagspan"><img class="flag" src="flags/svg/IQ-KRD.svg" /></span>
     <span class="doublewidespan">Kurmanji</span>
     <span class="widespan"><span class="hint--top hint--info" data-hint="1 treebank">1</span></span>
     <span class="widespan"><span class="hint--top hint--info" data-hint="10,189 tokens 10,260 words 754 sentences">10K</span></span>


### PR DESCRIPTION
My apologies! I should have done that in the previous PR (https://github.com/UniversalDependencies/universaldependencies.github.io/pull/4). Thus, I will use the same description I used for the previous PR: 

Changed the flag used for Northern Kurdish (Kurmanji) from the Turkish flag to the Kurdish flag (Ala Rengîn), which is formally used by the Kurdistan Regional Government in Iraq and it's currently used for the Central Kurdish (Sorani).

While Kurmanji is being spoken by Kurds in Turkey, the Turkish flag doesn't represent the Kurmanji or the Kurdish people. Thus, it's better to use the Kurdish flag that is used for Sorani.